### PR TITLE
Rename to opendds-performance-dashboard

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,9 +11,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      NAME: opendds-bench-scoreboard
+      NAME: opendds-performance-dashboard
     steps:
-      - name: Checkout opendds-bench-scoreboard
+      - name: Checkout opendds-performance-dashboard
         uses: actions/checkout@v3
       - name: Setup Node.js
         uses: actions/setup-node@v3

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# opendds-bench-scoreboard
+# opendds-performance-dashboard
 
 If running locally (on localhost),
 start the REST server that is required to get past CORS issues:

--- a/server/package.json
+++ b/server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "server",
   "version": "1.0.0",
-  "description": "OpenDSS Scoreboard server",
+  "description": "OpenDSS Performance Dashboard Server",
   "main": "index.js",
   "type": "module",
   "scripts": {
@@ -19,7 +19,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/oci-labs/opendds-bench-scoreboard.git"
+    "url": "https://github.com/OpenDDS/opendds-performance-dashboard.git"
   },
   "license": "ISC",
   "dependencies": {

--- a/ui/index.html
+++ b/ui/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width,initial-scale=1" />
 
-    <title>OpenDDS Bench Scoreboard</title>
+    <title>Bench Performance Dashboard</title>
     <link rel="icon" type="image/png" href="/favicon.png" />
     <link rel="stylesheet" href="/styles/c3.css" />
     <style>

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "opendds-bench-scoreboard",
+  "name": "opendds-performance-dashboard",
   "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,7 @@
 {
-  "name": "opendds-bench-scoreboard",
+  "name": "opendds-performance-dashboard",
   "version": "0.2.0",
+  "description": "OpenDSS Performance Dashboard UI",
   "scripts": {
     "build": "vite build",
     "check": "svelte-check --tsconfig ./tsconfig.json",
@@ -19,7 +20,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/oci-labs/opendds-bench-scoreboard.git"
+    "url": "https://github.com/OpenDDS/opendds-performance-dashboard.git"
   },
   "license": "ISC",
   "devDependencies": {

--- a/ui/src/App.svelte
+++ b/ui/src/App.svelte
@@ -193,7 +193,7 @@
       </div>
 
       <div class="right">
-        <h1 class="title">Bench Scoreboard</h1>
+        <h1 class="title">Bench Performance Dashboard</h1>
         <div class="buttons">
           <AppSharing />
           <button


### PR DESCRIPTION
Historically, the term "scoreboard" for OpenDDS has referred to a different site that tracks distributed build status, so the use of "scoreboard" here is unnecessarily confusing. We've taken to referring to this UI as the "performance dashboard", so we've renamed the repository and now need to change the name for a number of the repo's files.